### PR TITLE
#50 Feature "Include LICENSE in the release packages"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Generate compressed file for Linux
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
-          tar -czvf zork-linux.tar.gz ./dist/zork++
+          tar -czvf zork-linux.tar.gz ./dist/zork++ ./LICENSE
 
       - name: Upload Windows artifact
         if: ${{ matrix.os == 'windows-latest' }}

--- a/release-config/windows-installer-zork.iss
+++ b/release-config/windows-installer-zork.iss
@@ -39,6 +39,7 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "spanish"; MessagesFile: "compiler:Languages\Spanish.isl"
 
 [Files]
+Source: "..\LICENSE"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\dist\zork++.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\dist\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 


### PR DESCRIPTION
# Description

Fixes #50

# How Has This Been Tested?

The related steps in `.github/workflows/release.yml` were reproduced.
Namely:

1. Building Zork's exe with PyInstaller
2. Building the installer with Inno Setup
3. Generate compressed file for Linux

These changes have been tested in the following environment:

OS: Arch Linux
GNU tar: 1.34
Python: 3.10.9

Wine: 7.22
Python (Wine): 3.8.10
Inno Setup Compiler (Wine): 6.2.1

I was not able to produce a working `Zork++.exe` under Wine, mostly because newer python versions are not supported.
The installation process worked nonetheless with a stub.

